### PR TITLE
[Fix] Show players when are behind a transluced object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ deploy:
     repo: danielepantaleone/ioq3-for-UrbanTerror-4
     tags: true
 
-notifications:ake
+notifications: ake
   email:
     recipients:
     - danielepantaleone@me.com

--- a/code/server/sv_wallhack.c
+++ b/code/server/sv_wallhack.c
@@ -384,7 +384,7 @@ static int is_visible(vec3_t start, vec3_t end) {
 	trace_t trace;
 	CM_BoxTrace(&trace, start, end, NULL, NULL, 0, CONTENTS_SOLID, 0);
 
-	if (trace.contents & CONTENTS_SOLID) {
+	if ((trace.contents & CONTENTS_SOLID) && !(trace.contents & CONTENTS_TRANSLUCENT)) {
 		return 0;
 	}
 


### PR DESCRIPTION
The unique check that this code realise is if is solid, but a cristal is a solid, so all players will be hide if there are behind a cristal, we should check if it is translucent.

Incorrect yaml syntax.
